### PR TITLE
fix: add eslint-comments to plugins

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -17,7 +17,8 @@
     "lodash",
     "jest",
     "promise",
-    "markdown"
+    "markdown",
+    "eslint-comments"
   ],
   "settings": {
     "import/parsers": {


### PR DESCRIPTION
Add `eslint-comments` to plugins
Resolving error -
`Definition for rule 'eslint-comments/disable-enable-pair' was not found.`