### PR TITLE
release 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleartax/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleartax/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ClearTax Eslint Config",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Changelog
- Fix error on using `eslint-comments` https://github.com/ClearTax/eslint-config/pull/6
`Definition for rule 'eslint-comments/disable-enable-pair' was not found`